### PR TITLE
Add, remove, list devices.

### DIFF
--- a/src/commands/Information/adddevice.ts
+++ b/src/commands/Information/adddevice.ts
@@ -55,7 +55,6 @@ export default class extends Command {
                 await fetch('https://api.ipsw.me/v4/device/' + device.identifier + '?type=ipsw').then((r) => r.json())
             )['firmwares'];
             await loadingMessage.edit('What OS version are you on?\nEg. 13.3, 12.4');
-            console.log(firmwares);
             const firmwareCollector = new MessageCollector(
                 msg.channel as TextChannel,
                 (m) => m.author.id === msg.author.id,

--- a/src/commands/Information/adddevice.ts
+++ b/src/commands/Information/adddevice.ts
@@ -1,0 +1,84 @@
+import { Command, CommandStore, KlasaClient, KlasaMessage } from 'klasa';
+import fetch from 'node-fetch';
+import { Message, MessageCollector, TextChannel } from 'discord.js';
+
+interface APIFirmware {
+    identifier: string;
+    version: string;
+    buildid: string;
+    sha1sum: string;
+    md5sum: string;
+    filesize: string;
+    url: string;
+    releasedate: string;
+    uploaddate: string;
+    signed: boolean;
+}
+
+interface APIDevice {
+    name: string;
+    identifier: string;
+    boardconfig: string;
+    platform: string;
+    cpid: number;
+    bdid: number;
+}
+
+export default class extends Command {
+    constructor(client: KlasaClient, store: CommandStore, file: string[], dir: string) {
+        super(client, store, file, dir, {
+            enabled: true,
+            runIn: ['text'],
+            requiredPermissions: ['SEND_MESSAGES', 'MANAGE_NICKNAMES'],
+            requiredSettings: [],
+            aliases: ['add'],
+            guarded: false,
+            permissionLevel: 0,
+            description: 'Adds a device to your nickname.',
+        });
+    }
+
+    async run(msg: KlasaMessage) {
+        const nickname = msg.member.displayName;
+        if (/.+ \[.+, \d+\.\d+(\.\d+)?]/g.test(nickname))
+            return msg.send('Sorry, but your nickname already has a device. Use `!removedevice` to remove it.');
+        const devices: APIDevice[] = await fetch('https://api.ipsw.me/v4/devices').then((r) => r.json());
+        const deviceCollector = new MessageCollector(msg.channel as TextChannel, (m) => m.author.id === msg.author.id, {
+            max: 1,
+        });
+        await msg.send('What device are you using?\nEg. iPhone 11, iPhone 8 (GSM)');
+        deviceCollector.on('collect', async (deviceMessage: Message) => {
+            const device = devices.find((d) => d.name.toLowerCase() === deviceMessage.content.toLowerCase());
+            if (!device) return msg.channel.send("Sorry, but that's not a valid device. Not sure? Try `!listdevices`.");
+            const loadingMessage = await msg.channel.send('Loading OS versions...');
+            const firmwares: APIFirmware[] = (
+                await fetch('https://api.ipsw.me/v4/device/' + device.identifier + '?type=ipsw').then((r) => r.json())
+            )['firmwares'];
+            await loadingMessage.edit('What OS version are you on?\nEg. 13.3, 12.4');
+            console.log(firmwares);
+            const firmwareCollector = new MessageCollector(
+                msg.channel as TextChannel,
+                (m) => m.author.id === msg.author.id,
+                {
+                    max: 1,
+                },
+            );
+            firmwareCollector.on('collect', async (firmwareMessage: Message) => {
+                const firmware = firmwares.find((f) => f.version === firmwareMessage.content);
+                if (!firmware)
+                    return msg.channel.send("Sorry, that's not a valid OS version for this device. Try again.");
+                const finalString = ` [${device.name}, ${firmware.version}]`;
+                msg.member.setNickname(msg.member.displayName + finalString).then(
+                    () => {
+                        msg.channel.send('Success! Added' + finalString + ' to your nickname.');
+                    },
+                    () => {
+                        // error callback
+                        msg.channel.send("Oops! I don't have permissions to change your nickname.");
+                    },
+                );
+            });
+        });
+        return null;
+    }
+}

--- a/src/commands/Information/listdevices.ts
+++ b/src/commands/Information/listdevices.ts
@@ -1,0 +1,161 @@
+import { Command, CommandStore, KlasaClient, KlasaMessage, RichDisplay } from 'klasa';
+import fetch from 'node-fetch';
+import { MessageEmbed } from 'discord.js';
+
+interface APIDevice {
+    name: string;
+    identifier: string;
+    boardconfig: string;
+    platform: string;
+    cpid: number;
+    bdid: number;
+}
+
+export default class extends Command {
+    constructor(client: KlasaClient, store: CommandStore, file: string[], dir: string) {
+        super(client, store, file, dir, {
+            enabled: true,
+            runIn: ['text'],
+            requiredPermissions: ['SEND_MESSAGES'],
+            requiredSettings: [],
+            aliases: ['list'],
+            guarded: false,
+            permissionLevel: 0,
+            description: 'Lists devices available for !adddevice.',
+        });
+    }
+
+    async run(msg: KlasaMessage) {
+        const devices: APIDevice[] = await fetch('https://api.ipsw.me/v4/devices').then((r) => r.json());
+        const iPhonesEmbed1 = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('iPhone'))
+                .slice(0, 24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('iPhones [1/2]')
+            .setColor('GREEN');
+        const iPhonesEmbed2 = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('iPhone'))
+                .slice(24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('iPhones [2/2]')
+            .setColor('GREEN');
+        const iPadsEmbed1 = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('iPad'))
+                .slice(0, 24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('iPads [1/3]')
+            .setColor('GREEN');
+        const iPadsEmbed2 = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('iPad'))
+                .slice(24, 48)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('iPads [2/3]')
+            .setColor('GREEN');
+        const iPadsEmbed3 = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('iPad'))
+                .slice(48)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('iPads [3/3]')
+            .setColor('GREEN');
+        const aTVsEmbed = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('Apple TV'))
+                .slice(0, 24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('Apple TVs')
+            .setColor('GREEN');
+        const watchesEmbed = new MessageEmbed({
+            fields: devices
+                .filter((device) => device.name.startsWith('Apple Watch'))
+                .slice(0, 24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('Apple Watches')
+            .setColor('GREEN');
+        const otherEmbed = new MessageEmbed({
+            fields: devices
+                .filter(
+                    (device) =>
+                        !device.name.startsWith('iPhone') &&
+                        !device.name.startsWith('iPad') &&
+                        !device.name.startsWith('Apple TV') &&
+                        !device.name.startsWith('Apple Watch'),
+                )
+                .slice(0, 24)
+                .map((device) => {
+                    return {
+                        name: device.name,
+                        value: device.identifier,
+                    };
+                }),
+        })
+            .setTimestamp()
+            .setTitle('Other')
+            .setColor('GREEN');
+        const embed = new RichDisplay()
+            .setFooterSuffix('Provided by: ipsw.me')
+            .addPage(iPhonesEmbed1)
+            .addPage(iPhonesEmbed2)
+            .addPage(iPadsEmbed1)
+            .addPage(iPadsEmbed2)
+            .addPage(iPadsEmbed3)
+            .addPage(aTVsEmbed)
+            .addPage(watchesEmbed)
+            .addPage(otherEmbed);
+        embed.run(msg, { firstLast: false, jump: false, time: 120000 });
+        return null;
+    }
+}

--- a/src/commands/Information/removedevice.ts
+++ b/src/commands/Information/removedevice.ts
@@ -1,0 +1,34 @@
+import { Command, CommandStore, KlasaClient, KlasaMessage } from 'klasa';
+
+export default class extends Command {
+    constructor(client: KlasaClient, store: CommandStore, file: string[], dir: string) {
+        super(client, store, file, dir, {
+            enabled: true,
+            runIn: ['text'],
+            requiredPermissions: ['SEND_MESSAGES', 'MANAGE_NICKNAMES'],
+            requiredSettings: [],
+            aliases: ['remove'],
+            guarded: false,
+            permissionLevel: 0,
+            description: 'Removes a device from your nickname.',
+        });
+    }
+
+    async run(msg: KlasaMessage) {
+        const nickname = msg.member.displayName;
+        if (!/.+ \[.+, \d+\.\d+(\.\d+)?]/g.test(nickname)) return msg.send("You don't have a device in your nickname!");
+        const nicknameChars = nickname.split('');
+        const openIndex = nicknameChars.lastIndexOf('[');
+        const newNickname = nickname.slice(0, openIndex - 1);
+        msg.member.setNickname(newNickname).then(
+            () => {
+                msg.send('Removed a device from your nickname.');
+            },
+            () => {
+                // error callback
+                msg.send('There was an error setting your nickname!');
+            },
+        );
+        return null;
+    }
+}


### PR DESCRIPTION
Add !adddevice, !removedevice and !listdevices commands. Fetch data from ipsw.me API to not require any manual updates for the list. !listdevices shows all devices in a paged embed.
Supported all Apple devices that have IPSWs, so iPhones, iPads, iPods, Apple TVs, Apple Watches, HomePods, iBridges. Also doesn't allow you to set a version that's not supported by the device you picked (eg. 12.4 on an iPhone 11, 13.0 on an iPhone 6).